### PR TITLE
Ignore errors in drop database when the data file has already been de…

### DIFF
--- a/src/TemporaryDb/LocalDbDatabase.cs
+++ b/src/TemporaryDb/LocalDbDatabase.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.SqlClient;
+﻿using System;
+using System.Data.SqlClient;
 using System.IO;
 
 namespace TemporaryDb
@@ -75,7 +76,17 @@ END";
             using (var command = new SqlCommand(deleteIfExists, connection))
             {
                 connection.Open();
-                command.ExecuteNonQuery();
+
+                try
+                {
+                    command.ExecuteNonQuery();
+                }
+                catch (Exception) when (!File.Exists(_fileName))
+                {
+                    // If the file does not exist, we might get an exception when 
+                    // dropping the database.  LocalDB still removes to database
+                    // from sys.databases, so let's just eat this error and move on...
+                }
             }
 
             if (File.Exists(_fileName))

--- a/test/TemporaryDb.Tests/LocalDbDatabaseTests.cs
+++ b/test/TemporaryDb.Tests/LocalDbDatabaseTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -178,6 +179,28 @@ namespace TemporaryDb.Tests
 
             Assert.False(DatabaseExist(_db.MasterConnectionString, _databaseName));
 
+            _db.DropDatabase();
+        }
+
+        [Fact]
+        public void DropDatabaseIgnoresErrorsWhenDataFileDoesNotExist()
+        {
+            var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(directory);
+
+            var filename = Path.Combine(directory, _filename);
+            _db = new LocalDbDatabase(_databaseName, filename);
+
+            _db.CreateDatabase();
+
+            // Let the filesystem let go of the file so it isn't in use.
+            Thread.Sleep(250);
+
+            Directory.Delete(directory, true);
+
+            _db = new LocalDbDatabase(_databaseName);
+
+            _db.CreateDatabase();
             _db.DropDatabase();
         }
 


### PR DESCRIPTION
…leted.

This was happen on build servers where, for some reason, the data files where being deleted without telling Localdb.  The DB handles the case and removes the database from the sys.databases listing, but the sql command still throws an error.  Now we ignore the error if the database file doesn't exist.